### PR TITLE
Style header logo and fix z-index

### DIFF
--- a/app/(auth)/Header.tsx
+++ b/app/(auth)/Header.tsx
@@ -28,8 +28,9 @@ export default function Header() {
 
   return (
     <>
-      <div className="sm:w-full w-[175vw] h-[10vh]  flex">
-        <div className="flex sm:w-[30%]  justify-center sm:justify-start items-center w-[175vw]">
+      <div className="sm:w-full w-[175vw] h-[10vh] relative z-20 flex">
+        <div className="flex sm:w-[30%]  justify-center sm:justify-start items-center w-[175vw] gap-x-2">
+          <div className="bg-blue-500 w-6 h-6 rounded-sm"></div>
           <div className="text-2xl">Gst.IO</div>
         </div>
         {path !== "/generateOtp" && (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,8 +28,9 @@ export default function Header() {
 
   return (
     <>
-      <div className="sm:w-full w-[175vw] h-[10vh]  flex">
-        <div className="flex sm:w-[30%]  justify-center sm:justify-start items-center w-[175vw]">
+      <div className="sm:w-full w-[175vw] h-[10vh] relative z-20 flex">
+        <div className="flex sm:w-[30%]  justify-center sm:justify-start items-center w-[175vw] gap-x-2">
+          <div className="bg-blue-500 w-6 h-6 rounded-sm"></div>
           <div className="text-2xl">Gst.IO</div>
         </div>
         {path !== "/generateOtp" && (


### PR DESCRIPTION
Add blue logo block and elevate header z-index to prevent layout overlap.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab7bd530-a897-4b72-af5b-635e970bbc6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab7bd530-a897-4b72-af5b-635e970bbc6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

